### PR TITLE
Mineral selection is cleared on every purchase, no more ghost buying

### DIFF
--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -10,13 +10,13 @@ const facilityResources = getfacilityResources()
 const colonyResources = getColonyResources()
 //make variables that contain the facility and mineral selected from facilities module
 const transientState = getTransientState()
-
+let purchaseJustMade = false;
 export const Cart = () => {
     // creates the HTML in the cart
 
     let html = ""
 
-    if (transientState.selectedFacility) {
+    if (transientState.selectedFacility && !purchaseJustMade) {
 
         const facilityChosen = facilities.find(facility => facility.id === transientState.selectedFacility)
 
@@ -26,6 +26,11 @@ export const Cart = () => {
         html += `<div class="cartContents">
    ${transientState.quantity} tons of ${mineralChosen?.name} from ${facilityChosen?.name}
     </div>`
+    }
+    else {
+        html += `<div class="cartContents">
+    </div>`
+    purchaseJustMade = false;
     }
     return html;
 }
@@ -45,11 +50,7 @@ document.addEventListener(
             let facilityMineralId = null
             let colonyMineralId = null
 
-            const facilityMinerals = facilityResources.find(facilityResource => facilityResource.facilityId === transientState.selectedFacility)
-            facilityMineralId = facilityMinerals.id
-
-            const colonyMinerals = colonyResources.find(colonyResource => colonyResource.id === transientState.selectedColony)
-            colonyMineralId = colonyMinerals.id
+            
 
         renderCart()
     }
@@ -69,6 +70,8 @@ document.addEventListener(
         const foundFacilityResource = facilityResources.find(facilityResource => (facilityResource.facilityId === transientState.selectedFacility && facilityResource.mineralId === transientState.selectedMineral))
         substractFacilityMineral(foundFacilityResource.id)
         //renderFacilities();
+        transientState.quantity = 0;
+        purchaseJustMade = true;
         renderFacilityMinerals();
         renderCart();
         }

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -142,7 +142,7 @@ export const substractFacilityMineral = (facilityResourceId) => {
 // increment the quantity property
 export const addColonyMineral = (colonyResourceId) => {
     const colonyResourceObj = database.colonyResources.find(colonyResource => colonyResource.id === colonyResourceId)
-    colonyResourceObj.quantity++;
+    colonyResourceObj.quantity += database.transientState.quantity;
 }
 
 export const purchaseMineral = () => {


### PR DESCRIPTION
# Description

No more ghost buying, mineral selection is now cleared every time a purchase is made. AddColonyMineral function now adds based on the quantity of the transient state which is now correctly tracked and updated in the cart module.